### PR TITLE
Fix CI running all actions twice on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ master ]
 
 jobs:
   build-linux-gcc:


### PR DESCRIPTION
this style of CI makes it that it only runs on Pull requests and push to master branch, instead of all PRs and all pushes (includes push to PR which makes the  CI run twice each time)